### PR TITLE
Added pagination

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,11 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+    }),
+  );
   await app.listen(3000);
 }
 bootstrap();

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -13,6 +13,9 @@ import {
   UploadedFile,
   BadRequestException,
   Query,
+  DefaultValuePipe,
+  HttpStatus,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { PostDto } from './dto/post/post.dto';
 import { CreatePostDto } from './dto/post/create-post.dto';
@@ -25,7 +28,6 @@ import { RolesGuard } from 'src/auth/roles.guard';
 import { Roles } from 'src/auth/roles.decorator';
 import { RequestWithUser } from 'src/common/request-with-user.interface';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { Multer } from 'multer';
 
 @Controller('posts')
 export class PostController {
@@ -98,9 +100,14 @@ export class PostController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(1, 2)
   @Get()
-  async getAllPosts(@Req() req: RequestWithUser): Promise<PostDto[]> {
+  async getAllPosts(
+    @Req() req: RequestWithUser,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ): Promise<{ posts: PostDto[]; total: number }> {
     const { id, roleId } = req.user;
-    return this.postService.getAllPosts(id, roleId);
+
+    return this.postService.getAllPosts(id, roleId, page, limit);
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)


### PR DESCRIPTION
### Feature: Implement Pagination for Posts

**Description:**
- Added pagination support for retrieving posts with `page` and `limit` parameters.
- Utilized `ParseIntPipe` and `DefaultValuePipe` for clean and efficient parameter validation and conversion in the `getAllPosts` method.
- Ensured that:
  - Admins can view posts with any status.
  - Regular users can only view posts with the status "active" or their own posts.
- Updated `PostService` to handle paginated queries efficiently using Prisma transactions.

**Testing:**
- Tested pagination with various `page` and `limit` values.
- Verified that admins see all posts and regular users see only active posts or their own.